### PR TITLE
fix ks:load

### DIFF
--- a/lib/cassandra_object/tasks/keyspace.rb
+++ b/lib/cassandra_object/tasks/keyspace.rb
@@ -1,3 +1,5 @@
+require_relative 'column_family'
+
 module CassandraObject
 
   module Tasks


### PR DESCRIPTION
Probably a better way to fix this, but this works for now. 

Stack trace:

```
** Invoke ks:schema:load (first_time)
** Invoke ks:configure
** Execute ks:schema:load
rake aborted!
undefined method `with_fields' for #<Cassandra::ColumnFamily:0x007fd130d4a7c0>
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/sessionm-cassandra_object-2.7.5/lib/cassandra_object/tasks/keyspace.rb:11:in `block in parse'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/sessionm-cassandra_object-2.7.5/lib/cassandra_object/tasks/keyspace.rb:10:in `each'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/sessionm-cassandra_object-2.7.5/lib/cassandra_object/tasks/keyspace.rb:10:in `parse'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/sessionm-cassandra_object-2.7.5/lib/cassandra_object/tasks/ks.rake:124:in `block in schema_load'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/sessionm-cassandra_object-2.7.5/lib/cassandra_object/tasks/ks.rake:122:in `open'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/sessionm-cassandra_object-2.7.5/lib/cassandra_object/tasks/ks.rake:122:in `schema_load'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/sessionm-cassandra_object-2.7.5/lib/cassandra_object/tasks/ks.rake:90:in `block (3 levels) in <top (required)>'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/rake-10.0.4/lib/rake/task.rb:246:in `call'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/rake-10.0.4/lib/rake/task.rb:246:in `block in execute'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/rake-10.0.4/lib/rake/task.rb:241:in `each'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/rake-10.0.4/lib/rake/task.rb:241:in `execute'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/rake-10.0.4/lib/rake/task.rb:184:in `block in invoke_with_call_chain'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/rake-10.0.4/lib/rake/task.rb:177:in `invoke_with_call_chain'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/rake-10.0.4/lib/rake/task.rb:170:in `invoke'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/rake-10.0.4/lib/rake/application.rb:143:in `invoke_task'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/rake-10.0.4/lib/rake/application.rb:101:in `block (2 levels) in top_level'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/rake-10.0.4/lib/rake/application.rb:101:in `each'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/rake-10.0.4/lib/rake/application.rb:101:in `block in top_level'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/rake-10.0.4/lib/rake/application.rb:110:in `run_with_threads'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/rake-10.0.4/lib/rake/application.rb:95:in `top_level'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/rake-10.0.4/lib/rake/application.rb:73:in `block in run'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/rake-10.0.4/lib/rake/application.rb:160:in `standard_exception_handling'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/rake-10.0.4/lib/rake/application.rb:70:in `run'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/rake-10.0.4/bin/rake:33:in `<top (required)>'
/Users/agordon/.rbenv/versions/1.9.3-p551/bin/rake:23:in `load'
/Users/agordon/.rbenv/versions/1.9.3-p551/bin/rake:23:in `<top (required)>'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/bundler-1.17.1/lib/bundler/cli/exec.rb:74:in `load'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/bundler-1.17.1/lib/bundler/cli/exec.rb:74:in `kernel_load'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/bundler-1.17.1/lib/bundler/cli/exec.rb:28:in `run'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/bundler-1.17.1/lib/bundler/cli.rb:463:in `exec'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/bundler-1.17.1/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/bundler-1.17.1/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/bundler-1.17.1/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/bundler-1.17.1/lib/bundler/cli.rb:27:in `dispatch'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/bundler-1.17.1/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/bundler-1.17.1/lib/bundler/cli.rb:18:in `start'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/bundler-1.17.1/exe/bundle:30:in `block in <top (required)>'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/bundler-1.17.1/lib/bundler/friendly_errors.rb:124:in `with_friendly_errors'
/Users/agordon/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/bundler-1.17.1/exe/bundle:22:in `<top (required)>'
/Users/agordon/.rbenv/versions/1.9.3-p551/bin/bundle:23:in `load'
/Users/agordon/.rbenv/versions/1.9.3-p551/bin/bundle:23:in `<main>'
Tasks: TOP => ks:schema:load
```